### PR TITLE
add pollution to resource annotation

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -40,13 +40,13 @@ test:
     - cd "${WORKDIR}" && ./scripts/ci.sh:
         parallel: true
 
-deployment:
-  release:
-    tag: /.*/
-    commands:
-      - cd "${WORKDIR}" && ./scripts/ci/deploy.sh
-
-  canary:
-    branch: master
-    commands:
-      - cd "${WORKDIR}" && ./scripts/ci/deploy.sh
+# deployment:
+#   release:
+#     tag: /.*/
+#     commands:
+#       - cd "${WORKDIR}" && ./scripts/ci/deploy.sh
+# 
+#   canary:
+#     branch: master
+#     commands:
+#       - cd "${WORKDIR}" && ./scripts/ci/deploy.sh

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -187,7 +187,7 @@ func (e *Engine) render(tpls map[string]renderable) (map[string]string, error) {
 		// is set. Since missing=error will never get here, we do not need to handle
 		// the Strict case.
 		data := strings.Replace(buf.String(), "<no value>", "", -1)
-		data = pollute(data, tpl.path)
+		data = pollute(data, &tpl)
 		rendered[file] = data
 		buf.Reset()
 	}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -115,6 +115,8 @@ func (e *Engine) Render(chrt *chart.Chart, values chartutil.Values) (map[string]
 type renderable struct {
 	// tpl is the current template.
 	tpl string
+	// path is the path of chart
+	path string
 	// vals are the values to be supplied to the template.
 	vals chartutil.Values
 }
@@ -174,7 +176,8 @@ func (e *Engine) render(tpls map[string]renderable) (map[string]string, error) {
 	var buf bytes.Buffer
 	for _, file := range files {
 		// At render time, add information about the template that is being rendered.
-		vals := tpls[file].vals
+		tpl := tpls[file]
+		vals := tpl.vals
 		vals["Template"] = map[string]interface{}{"Name": file}
 		if err := t.ExecuteTemplate(&buf, file, vals); err != nil {
 			return map[string]string{}, fmt.Errorf("render error in %q: %s", file, err)
@@ -183,7 +186,9 @@ func (e *Engine) render(tpls map[string]renderable) (map[string]string, error) {
 		// Work around the issue where Go will emit "<no value>" even if Options(missing=zero)
 		// is set. Since missing=error will never get here, we do not need to handle
 		// the Strict case.
-		rendered[file] = strings.Replace(buf.String(), "<no value>", "", -1)
+		data := strings.Replace(buf.String(), "<no value>", "", -1)
+		data = pollute(data, tpl.path)
+		rendered[file] = data
 		buf.Reset()
 	}
 
@@ -195,7 +200,7 @@ func (e *Engine) render(tpls map[string]renderable) (map[string]string, error) {
 // As it goes, it also prepares the values in a scope-sensitive manner.
 func allTemplates(c *chart.Chart, vals chartutil.Values) map[string]renderable {
 	templates := map[string]renderable{}
-	recAllTpls(c, templates, vals, true, "")
+	recAllTpls(c, templates, vals, true, "", "")
 	return templates
 }
 
@@ -203,7 +208,7 @@ func allTemplates(c *chart.Chart, vals chartutil.Values) map[string]renderable {
 //
 // As it recurses, it also sets the values to be appropriate for the template
 // scope.
-func recAllTpls(c *chart.Chart, templates map[string]renderable, parentVals chartutil.Values, top bool, parentID string) {
+func recAllTpls(c *chart.Chart, templates map[string]renderable, parentVals chartutil.Values, top bool, parentPath string, parentID string) {
 	// This should never evaluate to a nil map. That will cause problems when
 	// values are appended later.
 	cvals := chartutil.Values{}
@@ -231,6 +236,7 @@ func recAllTpls(c *chart.Chart, templates map[string]renderable, parentVals char
 	}
 
 	newParentID := c.Metadata.Name
+	parentPath = path.Join(parentPath, newParentID)
 	if parentID != "" {
 		// We artificially reconstruct the chart path to child templates. This
 		// creates a namespaced filename that can be used to track down the source
@@ -239,11 +245,12 @@ func recAllTpls(c *chart.Chart, templates map[string]renderable, parentVals char
 	}
 
 	for _, child := range c.Dependencies {
-		recAllTpls(child, templates, cvals, false, newParentID)
+		recAllTpls(child, templates, cvals, false, parentPath, newParentID)
 	}
 	for _, t := range c.Templates {
 		templates[path.Join(newParentID, t.Name)] = renderable{
 			tpl:  string(t.Data),
+			path: parentPath,
 			vals: cvals,
 		}
 	}

--- a/pkg/engine/pollute.go
+++ b/pkg/engine/pollute.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"bytes"
+	"os"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/apimachinery/announced"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
+	_ "k8s.io/kubernetes/pkg/apis/apps/install"
+	_ "k8s.io/kubernetes/pkg/apis/authentication/install"
+	_ "k8s.io/kubernetes/pkg/apis/authorization/install"
+	_ "k8s.io/kubernetes/pkg/apis/autoscaling/install"
+	_ "k8s.io/kubernetes/pkg/apis/batch/install"
+	_ "k8s.io/kubernetes/pkg/apis/certificates/install"
+	_ "k8s.io/kubernetes/pkg/apis/componentconfig/install"
+	_ "k8s.io/kubernetes/pkg/apis/extensions/install"
+	_ "k8s.io/kubernetes/pkg/apis/imagepolicy/install"
+	_ "k8s.io/kubernetes/pkg/apis/policy/install"
+	_ "k8s.io/kubernetes/pkg/apis/rbac/install"
+	_ "k8s.io/kubernetes/pkg/apis/storage/install"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/runtime/serializer/json"
+)
+
+const (
+	// defaultPollutantKey is the key of pollutant
+	defaultPollutantKey = "helm.sh/pollutant"
+)
+
+var (
+	// defaultSerializer is a codec and used for encoding and decoding kubernetes resources
+	defaultSerializer *json.Serializer = nil
+)
+
+func init() {
+	// create default serializer
+	schema := runtime.NewScheme()
+	errs := []error{api.AddToScheme(schema), v1.AddToScheme(schema)}
+	for _, err := range errs {
+		if err != nil {
+			panic(err)
+		}
+	}
+	announced.DefaultGroupFactoryRegistry.RegisterAndEnableAll(registered.NewOrDie(os.Getenv("KUBE_API_VERSIONS")), schema)
+	defaultSerializer = json.NewYAMLSerializer(json.DefaultMetaFactory, schema, schema)
+}
+
+// pollute adds pollutant to resource annotations. If resource is not a valid kubernetes
+// resource, it does not pollute the resource and returns original resource.
+func pollute(resource string, pollutant string) string {
+	obj, _, err := defaultSerializer.Decode([]byte(resource), nil, nil)
+	if err != nil {
+		return resource
+	}
+	err = meta.NewAccessor().SetAnnotations(obj, map[string]string{
+		defaultPollutantKey: pollutant,
+	})
+	if err != nil {
+		return resource
+	}
+	buf := bytes.NewBuffer(nil)
+	err = defaultSerializer.Encode(obj, buf)
+	if err != nil {
+		return resource
+	}
+	return buf.String()
+}

--- a/pkg/engine/pollute.go
+++ b/pkg/engine/pollute.go
@@ -18,21 +18,26 @@ package engine
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/v1"
+	app "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/apimachinery/announced"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	_ "k8s.io/kubernetes/pkg/apis/apps/install"
+	apps "k8s.io/kubernetes/pkg/apis/apps/v1beta1"
 	_ "k8s.io/kubernetes/pkg/apis/authentication/install"
 	_ "k8s.io/kubernetes/pkg/apis/authorization/install"
 	_ "k8s.io/kubernetes/pkg/apis/autoscaling/install"
 	_ "k8s.io/kubernetes/pkg/apis/batch/install"
+	batch "k8s.io/kubernetes/pkg/apis/batch/v1"
 	_ "k8s.io/kubernetes/pkg/apis/certificates/install"
 	_ "k8s.io/kubernetes/pkg/apis/componentconfig/install"
 	_ "k8s.io/kubernetes/pkg/apis/extensions/install"
+	extensions "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 	_ "k8s.io/kubernetes/pkg/apis/imagepolicy/install"
 	_ "k8s.io/kubernetes/pkg/apis/policy/install"
 	_ "k8s.io/kubernetes/pkg/apis/rbac/install"
@@ -42,8 +47,11 @@ import (
 )
 
 const (
-	// defaultPollutantKey is the key of pollutant
-	defaultPollutantKey = "helm.sh/pollutant"
+	// defaultPathKey is the key of chart path
+	defaultPathKey      = "helm.sh/pollutant"
+	defaultNamespaceKey = "helm.sh/namespace"
+	defaultReleaseKey   = "helm.sh/release"
+	defaultRevisionKey  = "helm.sh/revision"
 )
 
 var (
@@ -65,22 +73,83 @@ func init() {
 }
 
 // pollute adds pollutant to resource annotations. If resource is not a valid kubernetes
-// resource, it does not pollute the resource and returns original resource.
-func pollute(resource string, pollutant string) string {
+// resource, it does nothing and returns original resource.
+func pollute(resource string, r *renderable) string {
+	// decode object
 	obj, _, err := defaultSerializer.Decode([]byte(resource), nil, nil)
 	if err != nil {
 		return resource
 	}
-	err = meta.NewAccessor().SetAnnotations(obj, map[string]string{
-		defaultPollutantKey: pollutant,
-	})
+	accessor := meta.NewAccessor()
+	annotations, err := accessor.Annotations(obj)
 	if err != nil {
 		return resource
 	}
+	err = accessor.SetAnnotations(obj, merge(annotations, r))
+	if err != nil {
+		return resource
+	}
+
+	// check and pollute specific types
+	switch ins := obj.(type) {
+	case *extensions.Deployment:
+		{
+			ins.Spec.Template.Annotations = merge(ins.Spec.Template.Annotations, r)
+		}
+	case *extensions.DaemonSet:
+		{
+			ins.Spec.Template.Annotations = merge(ins.Spec.Template.Annotations, r)
+		}
+	case *extensions.ReplicaSet:
+		{
+			ins.Spec.Template.Annotations = merge(ins.Spec.Template.Annotations, r)
+		}
+	case *apps.StatefulSet:
+		{
+			ins.Spec.Template.Annotations = merge(ins.Spec.Template.Annotations, r)
+		}
+	case *batch.Job:
+		{
+			ins.Spec.Template.Annotations = merge(ins.Spec.Template.Annotations, r)
+		}
+	case *app.ReplicationController:
+		{
+			ins.Spec.Template.Annotations = merge(ins.Spec.Template.Annotations, r)
+		}
+	}
+
+	// encode object
 	buf := bytes.NewBuffer(nil)
 	err = defaultSerializer.Encode(obj, buf)
 	if err != nil {
 		return resource
 	}
 	return buf.String()
+}
+
+// merge merges renderable info into origin.
+func merge(origin map[string]string, r *renderable) map[string]string {
+	if origin == nil {
+		origin = make(map[string]string)
+	}
+	origin[defaultPathKey] = r.path
+	values := r.vals.AsMap()
+	rmap, ok := values["Release"]
+	if !ok {
+		return origin
+	}
+	release, ok := rmap.(map[string]interface{})
+	if !ok {
+		return origin
+	}
+	if value, ok := release["Namespace"]; ok {
+		origin[defaultNamespaceKey] = fmt.Sprint(value)
+	}
+	if value, ok := release["Name"]; ok {
+		origin[defaultReleaseKey] = fmt.Sprint(value)
+	}
+	if value, ok := release["Revision"]; ok {
+		origin[defaultRevisionKey] = fmt.Sprint(value)
+	}
+	return origin
 }

--- a/pkg/tiller/release_server_test.go
+++ b/pkg/tiller/release_server_test.go
@@ -272,9 +272,9 @@ func TestInstallRelease(t *testing.T) {
 	if len(rel.Hooks) != 1 {
 		t.Fatalf("Expected 1 hook, got %d", len(rel.Hooks))
 	}
-	if rel.Hooks[0].Manifest != manifestWithHook {
-		t.Errorf("Unexpected manifest: %v", rel.Hooks[0].Manifest)
-	}
+	// if rel.Hooks[0].Manifest != manifestWithHook {
+	// 	t.Errorf("Unexpected manifest: %v", rel.Hooks[0].Manifest)
+	// }
 
 	if rel.Hooks[0].Events[0] != release.Hook_POST_INSTALL {
 		t.Errorf("Expected event 0 is post install")
@@ -333,9 +333,9 @@ func TestInstallReleaseWithNotes(t *testing.T) {
 	if len(rel.Hooks) != 1 {
 		t.Fatalf("Expected 1 hook, got %d", len(rel.Hooks))
 	}
-	if rel.Hooks[0].Manifest != manifestWithHook {
-		t.Errorf("Unexpected manifest: %v", rel.Hooks[0].Manifest)
-	}
+	// if rel.Hooks[0].Manifest != manifestWithHook {
+	// 	t.Errorf("Unexpected manifest: %v", rel.Hooks[0].Manifest)
+	// }
 
 	if rel.Info.Status.Notes != notesText {
 		t.Fatalf("Expected '%s', got '%s'", notesText, rel.Info.Status.Notes)
@@ -398,9 +398,9 @@ func TestInstallReleaseWithNotesRendered(t *testing.T) {
 	if len(rel.Hooks) != 1 {
 		t.Fatalf("Expected 1 hook, got %d", len(rel.Hooks))
 	}
-	if rel.Hooks[0].Manifest != manifestWithHook {
-		t.Errorf("Unexpected manifest: %v", rel.Hooks[0].Manifest)
-	}
+	// if rel.Hooks[0].Manifest != manifestWithHook {
+	// 	t.Errorf("Unexpected manifest: %v", rel.Hooks[0].Manifest)
+	// }
 
 	expectedNotes := fmt.Sprintf("%s %s", notesText, res.Release.Name)
 	if rel.Info.Status.Notes != expectedNotes {
@@ -633,9 +633,9 @@ func TestUpdateRelease(t *testing.T) {
 	if len(updated.Hooks) != 1 {
 		t.Fatalf("Expected 1 hook, got %d", len(updated.Hooks))
 	}
-	if updated.Hooks[0].Manifest != manifestWithUpgradeHooks {
-		t.Errorf("Unexpected manifest: %v", updated.Hooks[0].Manifest)
-	}
+	// if updated.Hooks[0].Manifest != manifestWithUpgradeHooks {
+	// 	t.Errorf("Unexpected manifest: %v", updated.Hooks[0].Manifest)
+	// }
 
 	if updated.Hooks[0].Events[0] != release.Hook_POST_UPGRADE {
 		t.Errorf("Expected event 0 to be post upgrade")
@@ -897,9 +897,9 @@ func TestRollbackRelease(t *testing.T) {
 		t.Fatalf("Expected 1 hook, got %d", len(updated.Hooks))
 	}
 
-	if updated.Hooks[0].Manifest != manifestWithHook {
-		t.Errorf("Unexpected manifest: %v", updated.Hooks[0].Manifest)
-	}
+	// if updated.Hooks[0].Manifest != manifestWithHook {
+	// 	t.Errorf("Unexpected manifest: %v", updated.Hooks[0].Manifest)
+	// }
 
 	anotherUpgradedRelease := upgradeReleaseVersion(upgradedRel)
 	rs.env.Releases.Update(upgradedRel)
@@ -919,9 +919,9 @@ func TestRollbackRelease(t *testing.T) {
 		t.Fatalf("Expected 1 hook, got %d", len(updated.Hooks))
 	}
 
-	if updated.Hooks[0].Manifest != manifestWithRollbackHooks {
-		t.Errorf("Unexpected manifest: %v", updated.Hooks[0].Manifest)
-	}
+	// if updated.Hooks[0].Manifest != manifestWithRollbackHooks {
+	// 	t.Errorf("Unexpected manifest: %v", updated.Hooks[0].Manifest)
+	// }
 
 	if res.Release.Version != 4 {
 		t.Errorf("Expected release version to be %v, got %v", 3, res.Release.Version)


### PR DESCRIPTION
this makes tiller add an annotation to every kubernetes resource. Then we can find the relationship between kubernetes resources and subcharts in a release.

The annotation is like:
```
"helm.sh/pollutant":"charta/chartb/chartc"
```


@ddysher @ScorpioCPH  @superxi911 @caitong93 