### PR TITLE
Fix an issue where resources not belonging to current release are mistakenly deleted

### DIFF
--- a/pkg/engine/pollute.go
+++ b/pkg/engine/pollute.go
@@ -17,114 +17,25 @@ limitations under the License.
 package engine
 
 import (
-	"bytes"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime/serializer/json"
-	"k8s.io/client-go/kubernetes/scheme"
-	app "k8s.io/client-go/pkg/api/v1"
-	apps "k8s.io/client-go/pkg/apis/apps/v1beta1"
-	batch "k8s.io/client-go/pkg/apis/batch/v1"
-	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	"k8s.io/helm/pkg/releaseutil"
 )
 
-const (
-	// defaultPathKey is the key of chart path
-	defaultPathKey      = "helm.sh/pollutant"
-	defaultNamespaceKey = "helm.sh/namespace"
-	defaultReleaseKey   = "helm.sh/release"
-	defaultRevisionKey  = "helm.sh/revision"
-)
-
-var (
-	// defaultSerializer is a codec and used for encoding and decoding kubernetes resources
-	defaultSerializer *json.Serializer = nil
-)
-
-func init() {
-	// create default serializer
-	defaultSerializer = json.NewYAMLSerializer(json.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
-}
-
-// pollute adds pollutant to resource annotations. If resource is not a valid kubernetes
-// resource, it does nothing and returns original resource.
+// pollute adds pollutant to resource annotations.
 func pollute(resource string, r *renderable) string {
-	// decode object
-	obj, _, err := defaultSerializer.Decode([]byte(resource), nil, nil)
-	if err != nil {
-		return resource
-	}
-	accessor := meta.NewAccessor()
-	annotations, err := accessor.Annotations(obj)
-	if err != nil {
-		return resource
-	}
-	err = accessor.SetAnnotations(obj, merge(annotations, r))
-	if err != nil {
-		return resource
-	}
-
-	// check and pollute specific types
-	switch ins := obj.(type) {
-	case *extensions.Deployment:
-		{
-			ins.Spec.Template.Annotations = merge(ins.Spec.Template.Annotations, r)
-		}
-	case *extensions.DaemonSet:
-		{
-			ins.Spec.Template.Annotations = merge(ins.Spec.Template.Annotations, r)
-		}
-	case *extensions.ReplicaSet:
-		{
-			ins.Spec.Template.Annotations = merge(ins.Spec.Template.Annotations, r)
-		}
-	case *apps.StatefulSet:
-		{
-			ins.Spec.Template.Annotations = merge(ins.Spec.Template.Annotations, r)
-		}
-	case *batch.Job:
-		{
-			ins.Spec.Template.Annotations = merge(ins.Spec.Template.Annotations, r)
-		}
-	case *app.ReplicationController:
-		{
-			ins.Spec.Template.Annotations = merge(ins.Spec.Template.Annotations, r)
-		}
-	}
-
-	// encode object
-	buf := bytes.NewBuffer(nil)
-	err = defaultSerializer.Encode(obj, buf)
-	if err != nil {
-		return resource
-	}
-	return buf.String()
-}
-
-// merge merges renderable info into origin.
-func merge(origin map[string]string, r *renderable) map[string]string {
-	if origin == nil {
-		origin = make(map[string]string)
-	}
-	origin[defaultPathKey] = r.path
+	annos := make(map[releaseutil.AnnotationKey]string)
 	values := r.vals.AsMap()
-	rmap, ok := values["Release"]
-	if !ok {
-		return origin
+	if rmap, ok := values["Release"]; ok {
+		if release, ok := rmap.(map[string]interface{}); ok {
+			if value, ok := release["Namespace"]; ok {
+				annos[releaseutil.DefaultNamespaceKey] = fmt.Sprint(value)
+			}
+			if value, ok := release["Name"]; ok {
+				annos[releaseutil.DefaultReleaseKey] = fmt.Sprint(value)
+			}
+		}
 	}
-	release, ok := rmap.(map[string]interface{})
-	if !ok {
-		return origin
-	}
-	if value, ok := release["Namespace"]; ok {
-		origin[defaultNamespaceKey] = fmt.Sprint(value)
-	}
-	if value, ok := release["Name"]; ok {
-		origin[defaultReleaseKey] = fmt.Sprint(value)
-	}
-	if value, ok := release["Revision"]; ok {
-		origin[defaultRevisionKey] = fmt.Sprint(value)
-	}
-	return origin
+	annos[releaseutil.DefaultPathKey] = r.path
+	return releaseutil.InjectAnnotations(resource, annos)
 }

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -49,6 +49,8 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 	"k8s.io/kubernetes/pkg/printers"
+
+	"k8s.io/helm/pkg/releaseutil"
 )
 
 // ErrNoObjectsVisited indicates that during a visit operation, no matching objects were found.
@@ -347,11 +349,23 @@ func createResource(info *resource.Info) error {
 }
 
 func deleteResource(c *Client, info *resource.Info) error {
+	helper := resource.NewHelper(info.Client, info.Mapping)
+	runningObj, err := helper.Get(info.Namespace, info.Name, info.Export)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	if !releaseutil.MatchRelease(info.VersionedObject, runningObj) {
+		log.Printf("Delete: Ignore unmatched object: %s/%s", info.Namespace, info.Name)
+		return nil
+	}
 	reaper, err := c.Reaper(info.Mapping)
 	if err != nil {
 		// If there is no reaper for this resources, delete it.
 		if kubectl.IsNoSuchReaperError(err) {
-			return resource.NewHelper(info.Client, info.Mapping).Delete(info.Namespace, info.Name)
+			return helper.Delete(info.Namespace, info.Name)
 		}
 		return err
 	}
@@ -390,6 +404,15 @@ func createPatch(mapping *meta.RESTMapping, target, current runtime.Object) ([]b
 }
 
 func updateResource(c *Client, target *resource.Info, currentObj runtime.Object, recreate bool) error {
+	helper := resource.NewHelper(target.Client, target.Mapping)
+	runningObj, err := helper.Get(target.Namespace, target.Name, target.Export)
+	if err != nil {
+		return err
+	}
+	if !releaseutil.MatchRelease(target.VersionedObject, runningObj) {
+		log.Printf("Update: Find unmatched object: %s/%s", target.Namespace, target.Name)
+		return fmt.Errorf("Update: Unmatched object: %s/%s", target.Namespace, target.Name)
+	}
 	patch, patchType, err := createPatch(target.Mapping, target.Object, currentObj)
 	if err != nil {
 		return fmt.Errorf("failed to create patch: %s", err)
@@ -405,7 +428,6 @@ func updateResource(c *Client, target *resource.Info, currentObj runtime.Object,
 	}
 
 	// send patch to server
-	helper := resource.NewHelper(target.Client, target.Mapping)
 	obj, err := helper.Patch(target.Namespace, target.Name, patchType, patch)
 	if err != nil {
 		return err

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -160,6 +160,8 @@ func TestUpdate(t *testing.T) {
 				return newResponse(200, &listA.Items[0])
 			case p == "/namespaces/default/pods/otter" && m == "GET":
 				return newResponse(200, &listA.Items[1])
+			case p == "/namespaces/default/pods/squid" && m == "GET":
+				return newResponse(200, &listA.Items[2])
 			case p == "/namespaces/default/pods/dolphin" && m == "GET":
 				return newResponse(404, notFoundBody())
 			case p == "/namespaces/default/pods/starfish" && m == "PATCH":
@@ -202,11 +204,14 @@ func TestUpdate(t *testing.T) {
 	// }
 	expectedActions := []string{
 		"/namespaces/default/pods/starfish:GET",
+		"/namespaces/default/pods/starfish:GET",
 		"/namespaces/default/pods/starfish:PATCH",
+		"/namespaces/default/pods/otter:GET",
 		"/namespaces/default/pods/otter:GET",
 		"/namespaces/default/pods/otter:GET",
 		"/namespaces/default/pods/dolphin:GET",
 		"/namespaces/default/pods:POST",
+		"/namespaces/default/pods/squid:GET",
 	}
 	if len(expectedActions) != len(actions) {
 		t.Errorf("unexpected number of requests, expected %d, got %d", len(expectedActions), len(actions))

--- a/pkg/releaseutil/annotation.go
+++ b/pkg/releaseutil/annotation.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package releaseutil
+
+import (
+	"bytes"
+	"log"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/client-go/kubernetes/scheme"
+	app "k8s.io/client-go/pkg/api/v1"
+	apps "k8s.io/client-go/pkg/apis/apps/v1beta1"
+	batch "k8s.io/client-go/pkg/apis/batch/v1"
+	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
+)
+
+// AnnotationKey is annotation key of kubernetes object
+type AnnotationKey string
+
+const (
+	// DefaultPathKey is the key of chart logic path. Logic path splits components by
+	// slash. For example:
+	// A chart like:
+	// rootchart --> subchart1
+	//           |-> subchart2
+	// The logic path of every charts:
+	// rootchart: rootchart
+	// subchart1: rootchart/subchart1
+	// subchart2: rootchart/subchart2
+	// If a kubernetes resource object have an annotation key named "helm.sh/path", Then
+	// its value should meet the requirements.
+	DefaultPathKey AnnotationKey = "helm.sh/path"
+	// defaultNamespaceKey is the key of release namespace
+	DefaultNamespaceKey AnnotationKey = "helm.sh/namespace"
+	// defaultReleaseKey is the key of release name
+	DefaultReleaseKey AnnotationKey = "helm.sh/release"
+)
+
+var (
+	// defaultSerializer is a codec and used for encoding and decoding kubernetes resources
+	defaultSerializer *json.Serializer = nil
+)
+
+func init() {
+	// create default serializer
+	defaultSerializer = json.NewYAMLSerializer(json.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
+}
+
+// InjectAnnotations adds key-value pairs to resource annotations. If resource is not a valid kubernetes
+// resource, it does nothing and returns original resource.
+func InjectAnnotations(resource string, annos map[AnnotationKey]string) string {
+	if len(annos) <= 0 {
+		return resource
+	}
+
+	// decode object
+	obj, _, err := defaultSerializer.Decode([]byte(resource), nil, nil)
+	if err != nil {
+		return resource
+	}
+	accessor := meta.NewAccessor()
+	annotations, err := accessor.Annotations(obj)
+	if err != nil {
+		return resource
+	}
+	err = accessor.SetAnnotations(obj, merge(annotations, annos))
+	if err != nil {
+		return resource
+	}
+
+	// check and add annotations to the template of specific types
+	switch ins := obj.(type) {
+	case *extensions.Deployment:
+		{
+			ins.Spec.Template.Annotations = merge(ins.Spec.Template.Annotations, annos)
+		}
+	case *extensions.DaemonSet:
+		{
+			ins.Spec.Template.Annotations = merge(ins.Spec.Template.Annotations, annos)
+		}
+	case *extensions.ReplicaSet:
+		{
+			ins.Spec.Template.Annotations = merge(ins.Spec.Template.Annotations, annos)
+		}
+	case *apps.StatefulSet:
+		{
+			ins.Spec.Template.Annotations = merge(ins.Spec.Template.Annotations, annos)
+		}
+	case *batch.Job:
+		{
+			ins.Spec.Template.Annotations = merge(ins.Spec.Template.Annotations, annos)
+		}
+	case *app.ReplicationController:
+		{
+			ins.Spec.Template.Annotations = merge(ins.Spec.Template.Annotations, annos)
+		}
+	}
+
+	// encode object
+	buf := bytes.NewBuffer(nil)
+	err = defaultSerializer.Encode(obj, buf)
+	if err != nil {
+		return resource
+	}
+	return buf.String()
+}
+
+// merge merges annotations into origin
+func merge(origin map[string]string, annos map[AnnotationKey]string) map[string]string {
+	if origin == nil {
+		origin = make(map[string]string)
+	}
+	for k, v := range annos {
+		origin[string(k)] = v
+	}
+	return origin
+}
+
+// MatchReleaseByString matches two object string and check if they are from same release
+func MatchReleaseByString(a, b string) bool {
+	// decode object
+	objA, _, err := defaultSerializer.Decode([]byte(a), nil, nil)
+	if err != nil {
+		log.Printf("match: Failed to decode resource: %s", err)
+		return false
+	}
+	objB, _, err := defaultSerializer.Decode([]byte(b), nil, nil)
+	if err != nil {
+		log.Printf("match: Failed to decode resource: %s", err)
+		return false
+	}
+	return MatchRelease(objA, objB)
+}
+
+// MatchRelease matches two object and check if they are from same release
+func MatchRelease(a, b runtime.Object) bool {
+	accessor := meta.NewAccessor()
+	annoA, err := accessor.Annotations(a)
+	if err != nil {
+		annoA = map[string]string{}
+	}
+	annoB, err := accessor.Annotations(b)
+	if err != nil {
+		annoB = map[string]string{}
+	}
+	return matchReleaseAnnotations(annoA, annoB)
+}
+
+// matchReleaseAnnotations checks path, namespace and release
+func matchReleaseAnnotations(a, b map[string]string) bool {
+	keys := []string{string(DefaultPathKey), string(DefaultNamespaceKey), string(DefaultReleaseKey)}
+	for _, key := range keys {
+		v1, ok1 := a[key]
+		v2, ok2 := b[key]
+		if !(ok1 || ok2) {
+			continue
+		}
+		if v1 != v2 {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Update:
- move engine utils to releaseutil
- check resource owner when update/delete release

Fix an issue that it will delete resources which do not belong to current release.
